### PR TITLE
Add support for a new friendly-name

### DIFF
--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -43,23 +43,35 @@ async def cli(host, password, debug):
     headers = {"x-secret-key": password}
     connector = TCPConnector(force_close=True)
     _session = ClientSession(headers=headers, connector=connector)
+
+    # Get Summary Info
     async with _session.get(
             url=f"https://{host}/api/v1/summary", ssl=False,
         ) as response:
             summary = await response.json()
-
     click.echo(click.style("== Summary info ==", bold=True))
     click.echo(json.dumps(summary, sort_keys=True, indent=2))
     click.echo()
+
+    # Get State Info
     async with _session.get(
             url=f"https://{host}/api/v1/state", ssl=False
         ) as response:
             state = await response.json()
-
     click.echo(click.style("== State info ==", bold=True))
     click.echo(json.dumps(state, sort_keys=True, indent=2))
 
-    final = {"state": state, "summary": summary}
+
+    # Get Name Info
+    async with _session.get(
+            url=f"https://{host}/api/v1/name", ssl=False
+        ) as response:
+            name = await response.json()
+    click.echo(click.style("== Name ==", bold=True))
+    click.echo(json.dumps(name, sort_keys=True, indent=2))
+
+
+    final = {"state": state, "summary": summary, "name": name}
     save_to = f"{summary['model']}_{summary['version']}.json"
     save = click.prompt(f"Do you want to save the above content to {save_to} (y/n)")
     if save == "y":

--- a/swidget/cli.py
+++ b/swidget/cli.py
@@ -77,10 +77,18 @@ async def cli(ctx, host, password, debug, type):
         return
 
     if type is not None:
-        dev = TYPE_TO_CLASS[type](host, password, False, False)
+        dev = TYPE_TO_CLASS[type](host=host,
+                                  token_name='x-secret-key',
+                                  secret_key=password,
+                                  ssl=False,
+                                  use_websockets=False)
     else:
         click.echo("No --type defined, discovering..")
-        dev = await discover_single(host, password, False, False)
+        dev = await discover_single(host=host,
+                                    token_name='x-secret-key',
+                                    password=password,
+                                    ssl=False,
+                                    use_websockets=False)
 
     await dev.update()
     ctx.obj = dev
@@ -135,6 +143,7 @@ async def hwinfo(dev):
 async def state(dev: SwidgetDevice):
     """Print out device state and versions."""
     click.echo(click.style(f"== {dev.friendly_name} - {dev.model} ==", bold=True))
+    click.echo(f"\tFriendly Name:  {dev.friendly_name}")
     click.echo(f"\tHost: {dev.ip_address}")
     click.echo(
         click.style(


### PR DESCRIPTION
This adds support for using the Swidget device's provisioned name (if available) instead of the generic host/insert type name.
