### PR TITLE
Minor fixes for websocket retry handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-swidget"
-version = "1.3.1"
+version = "1.3.2"
 description = "Python API for Swidget smart devices"
 license = "GPL-3.0-or-later"
 authors = ["Swidget"]
@@ -23,7 +23,7 @@ asyncclick = ">=8"
 pydantic = "^2"
 ssdp = "1.1.1"
 requests = "2.32.3"
-types-requests = "2.31.0.6"
+types-requests = "^2.3.0"
 urllib3 = '1.26.5'
 
 # required only for docs

--- a/swidget/swidgetdevice.py
+++ b/swidget/swidgetdevice.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Callable
 from enum import Enum
 from types import TracebackType
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from aiohttp import ClientSession, TCPConnector
 
@@ -98,11 +98,11 @@ class SwidgetDevice:
         """Property to represent if the client is connected to the device."""
         return self._websocket.connected
 
-    def get_websocket(self) -> SwidgetWebsocket | None:
+    def get_websocket(self) -> Optional[SwidgetWebsocket]:
         """Return the SwidgetWebsocket class instance if possible."""
         if self.use_websockets:
             return self._websocket
-        return None
+        raise RuntimeError("Swidget instance is not configured to use websockets")
 
     def set_countdown_timer(self, minutes) -> Any:
         """Set the countdown timer."""

--- a/swidget/websocket.py
+++ b/swidget/websocket.py
@@ -27,7 +27,7 @@ class SwidgetWebsocket:
         session: aiohttp.ClientSession | None = None,
         use_security: bool = True,
         retry_interval: int = 30,  # Initial retry interval in seconds
-        max_retries: int = 200,  # Maximum number of reconnection attempts
+        max_retries: int | None = None,  # Maximum number of reconnection attempts
     ):
         """Initialize the SwidgetWebsocket.
 
@@ -167,7 +167,7 @@ class SwidgetWebsocket:
         self.retry_count += 1
         delay = self.retry_interval * (2 ** (self.retry_count - 1))
         _LOGGER.warning(
-            f"Reconnecting in {delay} seconds (attempt {self.retry_count})..."
+            f"Reconnecting to Swidget device: {self.host} in {delay} seconds (attempt {self.retry_count})..."
         )
         await asyncio.sleep(delay)
         await self.connect()


### PR DESCRIPTION
1. Allowing infinite websocket retries by default
2. Allow wildcard 2.3.0.* of types-requests. 